### PR TITLE
Prep for custom codegen [1/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ name = "mincaml"
 version = "0.1.0"
 dependencies = [
  "cranelift-codegen",
+ "cranelift-entity",
  "cranelift-frontend",
  "cranelift-module",
  "cranelift-native",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "bin/test.rs"
 
 [dependencies]
 cranelift-codegen = "0.63"
+cranelift-entity = "0.63"
 cranelift-frontend = "0.63"
 cranelift-module = "0.63"
 cranelift-native = "0.63"

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,6 +1,5 @@
 use crate::cg_types::RepType;
 use crate::interner::{InternId, InternTable};
-use crate::lower::Label;
 use crate::type_check::{TyVar, Type};
 use crate::var::{CompilerPhase, Uniq, Var};
 
@@ -109,10 +108,6 @@ impl Ctx {
     fn fresh_builtin_var(&mut self, user_name: &str, symbol_name: &str) -> VarId {
         let uniq = self.fresh_uniq();
         self.intern_var(Var::new_builtin(user_name, symbol_name, uniq))
-    }
-
-    pub fn fresh_label(&mut self) -> Label {
-        self.fresh_uniq()
     }
 
     pub fn get_var(&self, id: VarId) -> Rc<Var> {

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -11,6 +11,8 @@ use crate::var::CompilerPhase::ClosureConvert;
 pub use print::*;
 pub use types::*;
 
+use cranelift_entity::PrimaryMap;
+
 // Used when debugging
 #[allow(unused_imports)]
 use crate::utils;
@@ -18,15 +20,15 @@ use crate::utils;
 use fxhash::FxHashSet;
 
 #[derive(Debug, Clone)]
-enum BlockSequel {
+enum Sequel {
     Return,
     // Assign return value to this variable and jump to the label. Used when lowering let bindings.
-    Asgn(VarId, Label),
+    Asgn(VarId, BlockIdx),
 }
 
-impl BlockSequel {
+impl Sequel {
     fn get_ret_var(&self, ctx: &mut CcCtx, ret_ty: RepType) -> VarId {
-        use BlockSequel::*;
+        use Sequel::*;
         match self {
             Asgn(var, _) => *var,
             Return => ctx.fresh_var(ret_ty),
@@ -34,60 +36,35 @@ impl BlockSequel {
     }
 }
 
-fn finish_block(
-    ctx: &mut CcCtx, label: Label, comment: Option<String>, mut stmts: Vec<Stmt>,
-    sequel: BlockSequel, value: Atom,
-) -> Block {
-    let exit = match sequel {
-        BlockSequel::Return => match value {
-            Atom::Unit => {
-                let tmp = ctx.fresh_var(RepType::Word);
-                stmts.push(Stmt::Asgn(Asgn {
-                    lhs: tmp,
-                    rhs: Expr::Atom(Atom::Unit),
-                }));
-                Exit::Return(tmp)
-            }
-            Atom::Int(i) => {
-                let tmp = ctx.fresh_var(RepType::Word);
-                stmts.push(Stmt::Asgn(Asgn {
-                    lhs: tmp,
-                    rhs: Expr::Atom(Atom::Int(i)),
-                }));
-                Exit::Return(tmp)
-            }
-            Atom::Float(f) => {
-                let tmp = ctx.fresh_var(RepType::Float);
-                stmts.push(Stmt::Asgn(Asgn {
-                    lhs: tmp,
-                    rhs: Expr::Atom(Atom::Float(f)),
-                }));
-                Exit::Return(tmp)
-            }
-            Atom::Var(var) => Exit::Return(var),
-        },
-        BlockSequel::Asgn(lhs, label) => {
-            match value {
-                // TODO: Should we handle this case in the call site? Or make it impossible to
-                // happen somehow?
-                Atom::Var(rhs) if lhs == rhs => {}
-                _ => {
-                    stmts.push(Stmt::Asgn(Asgn {
-                        lhs,
-                        rhs: Expr::Atom(value),
-                    }));
-                }
-            }
-            Exit::Jump(label)
-        }
-    };
+// A block currently being built
+struct BlockBuilder {
+    idx: BlockIdx,
+    stmts: Vec<Stmt>,
+    comment: Option<String>,
+}
 
-    Block {
-        label,
-        comment,
-        stmts,
-        exit,
+impl BlockBuilder {
+    fn new(idx: BlockIdx) -> Self {
+        Self {
+            idx,
+            stmts: vec![],
+            comment: None,
+        }
     }
+
+    fn asgn(&mut self, lhs: VarId, rhs: Expr) {
+        self.stmts.push(Stmt::Asgn(Asgn { lhs, rhs }));
+    }
+
+    fn expr(&mut self, expr: Expr) {
+        self.stmts.push(Stmt::Expr(expr));
+    }
+}
+
+struct FunSig {
+    name: VarId,
+    args: Vec<VarId>,
+    return_type: RepType,
 }
 
 // Closure conversion state
@@ -95,6 +72,8 @@ struct CcCtx<'ctx> {
     ctx: &'ctx mut Ctx,
     // Functions generated so far
     funs: Vec<Fun>,
+    // Blocks generated so far for the current function
+    blocks: PrimaryMap<BlockIdx, BlockData>,
 }
 
 impl<'ctx> CcCtx<'ctx> {
@@ -102,162 +81,170 @@ impl<'ctx> CcCtx<'ctx> {
         self.ctx.fresh_codegen_var(ClosureConvert, rep_type)
     }
 
-    fn fresh_label(&mut self) -> Label {
-        self.ctx.fresh_label()
+    fn create_block(&mut self) -> BlockBuilder {
+        let idx = self.blocks.push(BlockData::NA);
+        BlockBuilder::new(idx)
+    }
+
+    fn fork_fun<F: FnOnce(&mut CcCtx) -> FunSig>(&mut self, fork: F) {
+        let blocks = ::std::mem::replace(&mut self.blocks, PrimaryMap::new());
+        let FunSig {
+            name,
+            args,
+            return_type,
+        } = fork(self);
+        let fun_blocks = ::std::mem::replace(&mut self.blocks, blocks);
+        self.funs.push(Fun {
+            name,
+            args,
+            blocks: fun_blocks,
+            return_type,
+        });
+    }
+
+    fn finish_block(&mut self, block: BlockBuilder, sequel: Sequel, value: Atom) {
+        let BlockBuilder {
+            idx,
+            mut stmts,
+            comment,
+        } = block;
+
+        let exit = match sequel {
+            Sequel::Return => match value {
+                Atom::Unit => {
+                    let tmp = self.fresh_var(RepType::Word);
+                    stmts.push(Stmt::Asgn(Asgn {
+                        lhs: tmp,
+                        rhs: Expr::Atom(Atom::Unit),
+                    }));
+                    Exit::Return(tmp)
+                }
+                Atom::Int(i) => {
+                    let tmp = self.fresh_var(RepType::Word);
+                    stmts.push(Stmt::Asgn(Asgn {
+                        lhs: tmp,
+                        rhs: Expr::Atom(Atom::Int(i)),
+                    }));
+                    Exit::Return(tmp)
+                }
+                Atom::Float(f) => {
+                    let tmp = self.fresh_var(RepType::Float);
+                    stmts.push(Stmt::Asgn(Asgn {
+                        lhs: tmp,
+                        rhs: Expr::Atom(Atom::Float(f)),
+                    }));
+                    Exit::Return(tmp)
+                }
+                Atom::Var(var) => Exit::Return(var),
+            },
+            Sequel::Asgn(lhs, label) => {
+                match value {
+                    // TODO: Should we handle this case in the call site? Or make it impossible to
+                    // happen somehow?
+                    Atom::Var(rhs) if lhs == rhs => {}
+                    _ => {
+                        stmts.push(Stmt::Asgn(Asgn {
+                            lhs,
+                            rhs: Expr::Atom(value),
+                        }));
+                    }
+                }
+                Exit::Jump(label)
+            }
+        };
+
+        let block = Block {
+            idx,
+            comment,
+            stmts,
+            exit,
+        };
+
+        self.finish_block_(block);
+    }
+
+    fn finish_block_(&mut self, block: Block) {
+        let idx = block.idx;
+        assert!(self.blocks[idx].is_NA());
+        self.blocks[idx] = BlockData::Block(block);
     }
 }
 
 pub fn lower_pgm(ctx: &mut Ctx, expr: anormal::Expr) -> (Vec<Fun>, VarId) {
-    let mut cc_ctx = CcCtx { ctx, funs: vec![] };
+    let mut ctx = CcCtx {
+        ctx,
+        funs: vec![],
+        blocks: PrimaryMap::new(),
+    };
 
-    let main_name = cc_ctx.fresh_var(RepType::Word);
-    let mut main_blocks = vec![];
-    let entry_label = cc_ctx.fresh_label();
-    cc_block(
-        &mut cc_ctx,
-        &mut main_blocks,
-        entry_label,
-        vec![],
-        BlockSequel::Return,
-        expr,
-    );
+    let main_name = ctx.fresh_var(RepType::Word);
+    let main_block = ctx.create_block();
+    cc_block(&mut ctx, main_block, Sequel::Return, expr);
 
-    cc_ctx.funs.push(Fun {
+    ctx.funs.push(Fun {
         name: main_name,
         args: vec![],
-        blocks: main_blocks,
+        blocks: ctx.blocks,
         return_type: RepType::Word,
     });
 
-    (cc_ctx.funs, main_name)
+    (ctx.funs, main_name)
 }
 
 // Returns whether the added block was a fork (i.e. then or else branch of an if)
-fn cc_block(
-    ctx: &mut CcCtx, blocks: &mut Vec<Block>, label: Label, mut stmts: Vec<Stmt>,
-    sequel: BlockSequel, expr: anormal::Expr,
-) -> bool {
+fn cc_block(ctx: &mut CcCtx, mut block: BlockBuilder, sequel: Sequel, expr: anormal::Expr) {
     match expr {
-        anormal::Expr::Unit => {
-            blocks.push(finish_block(ctx, label, None, stmts, sequel, Atom::Unit));
-            false
-        }
+        anormal::Expr::Unit => ctx.finish_block(block, sequel, Atom::Unit),
 
-        anormal::Expr::Int(i) => {
-            blocks.push(finish_block(ctx, label, None, stmts, sequel, Atom::Int(i)));
-            false
-        }
+        anormal::Expr::Int(i) => ctx.finish_block(block, sequel, Atom::Int(i)),
 
-        anormal::Expr::Float(f) => {
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Float(f),
-            ));
-            false
-        }
+        anormal::Expr::Float(f) => ctx.finish_block(block, sequel, Atom::Float(f)),
 
         anormal::Expr::Neg(var) => {
             let tmp = ctx.fresh_var(RepType::Word);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: tmp,
-                rhs: Expr::Neg(var),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(tmp),
-            ));
-            false
+            block.asgn(tmp, Expr::Neg(var));
+            ctx.finish_block(block, sequel, Atom::Var(tmp));
         }
 
         anormal::Expr::FNeg(var) => {
             let tmp = ctx.fresh_var(RepType::Float);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: tmp,
-                rhs: Expr::FNeg(var),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(tmp),
-            ));
-            false
+            block.asgn(tmp, Expr::FNeg(var));
+            ctx.finish_block(block, sequel, Atom::Var(tmp));
         }
 
         anormal::Expr::IBinOp(BinOp { op, arg1, arg2 }) => {
             let tmp = sequel.get_ret_var(ctx, RepType::Word);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: tmp,
-                rhs: Expr::IBinOp(BinOp { op, arg1, arg2 }),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(tmp),
-            ));
-            false
+            block.asgn(tmp, Expr::IBinOp(BinOp { op, arg1, arg2 }));
+            ctx.finish_block(block, sequel, Atom::Var(tmp));
         }
 
         anormal::Expr::FBinOp(BinOp { op, arg1, arg2 }) => {
             let tmp = sequel.get_ret_var(ctx, RepType::Float);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: tmp,
-                rhs: Expr::FBinOp(BinOp { op, arg1, arg2 }),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(tmp),
-            ));
-            false
+            block.asgn(tmp, Expr::FBinOp(BinOp { op, arg1, arg2 }));
+            ctx.finish_block(block, sequel, Atom::Var(tmp));
         }
 
         anormal::Expr::If(v1, v2, cmp, e1, e2) => {
-            let then_label = ctx.fresh_label();
-            let else_label = ctx.fresh_label();
-            blocks.push(Block {
-                label,
-                comment: None,
-                stmts,
+            let then_block = ctx.create_block();
+            let else_block = ctx.create_block();
+            ctx.finish_block_(Block {
+                idx: block.idx,
+                comment: block.comment,
+                stmts: block.stmts,
                 exit: Exit::Branch {
                     v1,
                     v2,
                     cond: cmp,
-                    then_label,
-                    else_label,
+                    then_block: then_block.idx,
+                    else_block: else_block.idx,
                 },
             });
-            cc_block(ctx, blocks, then_label, vec![], sequel.clone(), *e1);
-            cc_block(ctx, blocks, else_label, vec![], sequel, *e2);
-            true
+            cc_block(ctx, then_block, sequel.clone(), *e1);
+            cc_block(ctx, else_block, sequel, *e2);
         }
 
         anormal::Expr::Var(var) => {
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(var),
-            ));
-            false
+            ctx.finish_block(block, sequel, Atom::Var(var));
         }
 
         anormal::Expr::Let {
@@ -266,25 +253,12 @@ fn cc_block(
             rhs,
             body,
         } => {
-            let cont_label = ctx.fresh_label();
-            let rhs_sequel = BlockSequel::Asgn(id, cont_label);
-            let forked = cc_block(ctx, blocks, label, stmts, rhs_sequel, *rhs);
-
-            // Is the last block of RHS is not a forked block (i.e. then or else branch of an if)
-            // then we can continue extend that block. If not we'll have to use the continuation
-            // block.
-            if !forked {
-                let Block {
-                    label,
-                    comment: _,
-                    stmts,
-                    exit,
-                } = blocks.pop().unwrap();
-                assert_eq!(exit, Exit::Jump(cont_label));
-                cc_block(ctx, blocks, label, stmts, sequel, *body)
-            } else {
-                cc_block(ctx, blocks, cont_label, vec![], sequel, *body)
-            }
+            // TODO: When the RHS is not if-then-else we can continue extending the last block RHS
+            // generates and avoid creating a block for the continuation.
+            let cont_block = ctx.create_block();
+            let rhs_sequel = Sequel::Asgn(id, cont_block.idx);
+            cc_block(ctx, block, rhs_sequel, *rhs);
+            cc_block(ctx, cont_block, sequel, *body)
         }
 
         anormal::Expr::LetRec {
@@ -320,60 +294,46 @@ fn cc_block(
 
             // Emit function
             args.insert(0, name); // first argument will be 'self'
-            let fun_entry_label = ctx.fresh_label();
-            let mut fun_blocks = vec![];
-            let mut entry_block_stmts = vec![];
-            // Bind captured variables in function body
-            for (fv_idx, fv) in closure_fvs.iter().enumerate() {
-                entry_block_stmts.push(Stmt::Asgn(Asgn {
-                    lhs: *fv,
-                    rhs: Expr::TupleGet(name, fv_idx + 1),
-                }));
-            }
-            cc_block(
-                ctx,
-                &mut fun_blocks,
-                fun_entry_label,
-                entry_block_stmts,
-                BlockSequel::Return,
-                *rhs,
-            );
+            ctx.fork_fun(|ctx| {
+                let mut entry_block = ctx.create_block();
+                // Bind captured variables in function body
+                for (fv_idx, fv) in closure_fvs.iter().enumerate() {
+                    entry_block.asgn(*fv, Expr::TupleGet(name, fv_idx + 1));
+                }
+                cc_block(ctx, entry_block, Sequel::Return, *rhs);
 
-            let fun_type = ctx.ctx.get_type(ty_id);
-            let fun_return_type = match &*fun_type {
-                Type::Fun { ret, .. } => RepType::from(&**ret),
-                _ => panic!("Non-function in function position"),
-            };
+                let fun_type = ctx.ctx.get_type(ty_id);
+                let fun_return_type = match &*fun_type {
+                    Type::Fun { ret, .. } => RepType::from(&**ret),
+                    _ => panic!("Non-function in function position"),
+                };
 
-            ctx.funs.push(Fun {
-                name: fun_var,
-                args,
-                blocks: fun_blocks,
-                return_type: fun_return_type,
+                FunSig {
+                    name: fun_var,
+                    args,
+                    return_type: fun_return_type,
+                }
             });
 
             // Body
             let mut closure_tuple_args = closure_fvs;
             closure_tuple_args.insert(0, fun_var);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: name,
-                rhs: Expr::Tuple {
+            block.asgn(
+                name,
+                Expr::Tuple {
                     len: closure_tuple_args.len(),
                 },
-            }));
+            );
             for (arg_idx, arg) in closure_tuple_args.iter().enumerate() {
-                stmts.push(Stmt::Expr(Expr::TuplePut(name, arg_idx, *arg)));
+                block.expr(Expr::TuplePut(name, arg_idx, *arg));
             }
-            cc_block(ctx, blocks, label, stmts, sequel, *body)
+            cc_block(ctx, block, sequel, *body)
         }
 
         anormal::Expr::App(fun, mut args) => {
             // f(x) -> f.0(f, x)
             let fun_tmp = ctx.fresh_var(RepType::Word);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: fun_tmp,
-                rhs: Expr::TupleGet(fun, 0),
-            }));
+            block.asgn(fun_tmp, Expr::TupleGet(fun, 0));
             args.insert(0, fun);
 
             let fun_ret_ty = match &*ctx.ctx.var_type(fun) {
@@ -382,39 +342,17 @@ fn cc_block(
             };
             let ret_tmp = sequel.get_ret_var(ctx, fun_ret_ty);
 
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: ret_tmp,
-                rhs: Expr::App(fun_tmp, args, fun_ret_ty),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(ret_tmp),
-            ));
-            false
+            block.asgn(ret_tmp, Expr::App(fun_tmp, args, fun_ret_ty));
+            ctx.finish_block(block, sequel, Atom::Var(ret_tmp));
         }
 
         anormal::Expr::Tuple(args) => {
             let ret_tmp = sequel.get_ret_var(ctx, RepType::Word);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: ret_tmp,
-                rhs: Expr::Tuple { len: args.len() },
-            }));
+            block.asgn(ret_tmp, Expr::Tuple { len: args.len() });
             for (arg_idx, arg) in args.iter().enumerate() {
-                stmts.push(Stmt::Expr(Expr::TuplePut(ret_tmp, arg_idx, *arg)));
+                block.expr(Expr::TuplePut(ret_tmp, arg_idx, *arg));
             }
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(ret_tmp),
-            ));
-            false
+            ctx.finish_block(block, sequel, Atom::Var(ret_tmp));
         }
 
         anormal::Expr::TupleGet(tuple, idx) => {
@@ -426,92 +364,62 @@ fn cc_block(
                 ),
             };
             let ret_tmp = sequel.get_ret_var(ctx, elem_ty);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: ret_tmp,
-                rhs: Expr::TupleGet(tuple, idx),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(ret_tmp),
-            ));
-            false
+            block.asgn(ret_tmp, Expr::TupleGet(tuple, idx));
+            ctx.finish_block(block, sequel, Atom::Var(ret_tmp));
         }
 
         anormal::Expr::ArrayAlloc { len, elem } => {
             let array_tmp = sequel.get_ret_var(ctx, RepType::Word);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: array_tmp,
-                rhs: Expr::ArrayAlloc { len },
-            }));
+            block.asgn(array_tmp, Expr::ArrayAlloc { len });
 
             let idx_var = ctx.fresh_var(RepType::Word);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: idx_var,
-                rhs: Expr::Atom(Atom::Int(0)),
-            }));
+            block.asgn(idx_var, Expr::Atom(Atom::Int(0)));
 
-            let loop_cond_label = ctx.fresh_label();
-            let loop_body_label = ctx.fresh_label();
-            let cont_label = ctx.fresh_label();
+            let loop_cond_block = ctx.create_block();
+            let mut loop_body_block = ctx.create_block();
+            let cont_block = ctx.create_block();
 
-            blocks.push(Block {
-                label,
-                comment: None,
-                stmts,
-                exit: Exit::Jump(loop_cond_label),
+            ctx.finish_block_(Block {
+                idx: block.idx,
+                comment: block.comment,
+                stmts: block.stmts,
+                exit: Exit::Jump(loop_cond_block.idx),
             });
 
             // loop_cond
-            blocks.push(Block {
-                label: loop_cond_label,
+            ctx.finish_block_(Block {
+                idx: loop_cond_block.idx,
                 comment: Some("array loop cond".to_string()),
                 stmts: vec![],
                 exit: Exit::Branch {
                     v1: idx_var,
                     v2: len,
                     cond: Cmp::Equal,
-                    then_label: cont_label,
-                    else_label: loop_body_label,
+                    then_block: cont_block.idx,
+                    else_block: loop_body_block.idx,
                 },
             });
 
             // loop_body
             let idx_inc_var = ctx.fresh_var(RepType::Word);
-            let loop_body_stmts = vec![
-                Stmt::Expr(Expr::ArrayPut(array_tmp, idx_var, elem)),
-                Stmt::Asgn(Asgn {
-                    lhs: idx_inc_var,
-                    rhs: Expr::Atom(Atom::Int(1)),
+            loop_body_block.expr(Expr::ArrayPut(array_tmp, idx_var, elem));
+            loop_body_block.asgn(idx_inc_var, Expr::Atom(Atom::Int(1)));
+            loop_body_block.asgn(
+                idx_var,
+                Expr::IBinOp(BinOp {
+                    op: IntBinOp::Add,
+                    arg1: idx_var,
+                    arg2: idx_inc_var,
                 }),
-                Stmt::Asgn(Asgn {
-                    lhs: idx_var,
-                    rhs: Expr::IBinOp(BinOp {
-                        op: IntBinOp::Add,
-                        arg1: idx_var,
-                        arg2: idx_inc_var,
-                    }),
-                }),
-            ];
-            blocks.push(Block {
-                label: loop_body_label,
+            );
+            ctx.finish_block_(Block {
+                idx: loop_body_block.idx,
                 comment: Some("array body".to_string()),
-                stmts: loop_body_stmts,
-                exit: Exit::Jump(loop_cond_label),
+                stmts: loop_body_block.stmts,
+                exit: Exit::Jump(loop_cond_block.idx),
             });
 
-            blocks.push(finish_block(
-                ctx,
-                cont_label,
-                Some("array cont".to_string()),
-                vec![],
-                sequel,
-                Atom::Var(array_tmp),
-            ));
-            false
+            ctx.finish_block(cont_block, sequel, Atom::Var(array_tmp));
         }
 
         anormal::Expr::ArrayGet(array, idx) => {
@@ -523,19 +431,8 @@ fn cc_block(
                 ),
             };
             let ret_tmp = sequel.get_ret_var(ctx, elem_ty);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: ret_tmp,
-                rhs: Expr::ArrayGet(array, idx),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(ret_tmp),
-            ));
-            false
+            block.asgn(ret_tmp, Expr::ArrayGet(array, idx));
+            ctx.finish_block(block, sequel, Atom::Var(ret_tmp));
         }
 
         anormal::Expr::ArrayPut(array, idx, val) => {
@@ -547,19 +444,8 @@ fn cc_block(
                 ),
             };
             let ret_tmp = sequel.get_ret_var(ctx, elem_ty);
-            stmts.push(Stmt::Asgn(Asgn {
-                lhs: ret_tmp,
-                rhs: Expr::ArrayPut(array, idx, val),
-            }));
-            blocks.push(finish_block(
-                ctx,
-                label,
-                None,
-                stmts,
-                sequel,
-                Atom::Var(ret_tmp),
-            ));
-            false
+            block.asgn(ret_tmp, Expr::ArrayPut(array, idx, val));
+            ctx.finish_block(block, sequel, Atom::Var(ret_tmp));
         }
     }
 }

--- a/src/lower/print.rs
+++ b/src/lower/print.rs
@@ -36,8 +36,13 @@ impl Fun {
         print_comma_sep(ctx, &mut args.iter(), pp_id_ref, w)?;
         writeln!(w, ") -> {}", return_type)?;
 
-        for block in blocks {
-            block.pp(ctx, w)?;
+        for block in blocks.values() {
+            match block {
+                BlockData::NA => {}
+                BlockData::Block(block) => {
+                    block.pp(ctx, w)?;
+                }
+            }
         }
         writeln!(w)
     }
@@ -46,12 +51,12 @@ impl Fun {
 impl Block {
     pub fn pp(&self, ctx: &Ctx, w: &mut dyn fmt::Write) -> Result<(), fmt::Error> {
         let Block {
-            label,
+            idx,
             comment,
             stmts,
             exit,
         } = self;
-        write!(w, "{}:", label)?;
+        write!(w, "{}:", idx)?;
         match comment {
             None => {
                 writeln!(w)?;
@@ -83,14 +88,14 @@ impl Exit {
                 v1,
                 v2,
                 cond,
-                then_label,
-                else_label,
+                then_block,
+                else_block,
             } => {
                 w.write_str("if ")?;
                 pp_id(ctx, *v1, w)?;
                 write!(w, " {} ", cond)?;
                 pp_id(ctx, *v2, w)?;
-                write!(w, " then {} else {}", then_label, else_label)
+                write!(w, " then {} else {}", then_block, else_block)
             }
             Jump(lbl) => write!(w, "jump {}", lbl),
         }


### PR DESCRIPTION
For liveness analysis we need CFG for functions, and for that we need to be able to map blocks to predecessors and sucessors. This is possible to do with a the previous `Uniq` type, but having a more dense representation (where blocks always start from 0 in a function) allows using more compact and efficient types like cranelift's `PrimaryMap` and `SecondaryMap`.

Also fixes a bug in codegen where we'd previously use some locals before declaring.